### PR TITLE
黑色模式下个别地方优化

### DIFF
--- a/V2EX/ViewControllers/Account/LoginViewController.swift
+++ b/V2EX/ViewControllers/Account/LoginViewController.swift
@@ -429,6 +429,7 @@ extension LoginViewController {
             webViewVC.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "获取 Cookie", style: .plain) { [weak self] in
                 self?.analysisLoginResult(webViewVC.webView)
             }
+            webViewVC.navigationController?.navigationBar.tintColor = ThemeStyle.style.value.tintColor
         }
     }
     

--- a/V2EX/ViewControllers/Base/SweetWebViewController.swift
+++ b/V2EX/ViewControllers/Base/SweetWebViewController.swift
@@ -152,6 +152,10 @@ open class SweetWebViewController: UIViewController {
 
         rollbackState()
     }
+    
+    open override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ThemeStyle.style.value.statusBarStyle
+    }
 
     override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         switch keyPath {

--- a/V2EX/ViewControllers/Home/TopicSearchResultViewController.swift
+++ b/V2EX/ViewControllers/Home/TopicSearchResultViewController.swift
@@ -218,6 +218,7 @@ class TopicSearchResultViewController: DataViewController, TopicService {
                 self?.searchTextField.keyboardAppearance = theme.keyboardAppeareance
                 self?.searchTextField.backgroundColor = theme.bgColor
                 self?.searchTextField.textColor = theme.titleColor
+                self?.searchTextField.tintColor = theme.tintColor
                 self?.containerView.borderBottom = Border(color: theme.borderColor)
                 self?.searchTextField.setValue(theme.dateColor, forKeyPath: "_placeholderLabel.textColor")
                 self?.segmentView.tintColor = theme.tintColor

--- a/V2EX/Views/CommentInputView.swift
+++ b/V2EX/Views/CommentInputView.swift
@@ -23,7 +23,7 @@ class CommentInputView: UIView {
         view.backgroundColor = Theme.Color.bgColor
         view.delegate = self
         view.textParser = MentionedParser()
-        view.tintColor = Theme.Color.globalColor
+        view.tintColor = ThemeStyle.style.value.tintColor
         var contentInset = view.contentInset
         contentInset.right = -35
         view.contentInset = contentInset
@@ -119,6 +119,7 @@ class CommentInputView: UIView {
                 self?.textView.layer.borderColor = (theme == .day ? theme.borderColor : UIColor.hex(0x19171A)).cgColor
                 self?.textView.keyboardAppearance = theme.keyboardAppeareance
                 self?.textView.textColor = theme.titleColor
+                self?.textView.tintColor = theme.tintColor
                 self?.sendBtn.tintColor = theme == .day ? theme.tintColor : .white
             }.disposed(by: rx.disposeBag)
     }

--- a/V2EX/Views/ShareSheetView.swift
+++ b/V2EX/Views/ShareSheetView.swift
@@ -117,7 +117,7 @@ public class ShareSheetView: UIView {
             let origin_y = tHeight + Metric.cardHeight * CGFloat(index) + Metric.divideLineHeight * CGFloat(index)
             
             let scroller = UIScrollView(frame: CGRect(x: 0.0, y: origin_y, width: width, height: Metric.cardHeight))
-            scroller.backgroundColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.80)
+            scroller.backgroundColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1.00).withAlphaComponent(0.8)
             scroller.showsHorizontalScrollIndicator = false
             scroller.showsVerticalScrollIndicator = false
             let contentSizeWidth = CGFloat(section.count) * Metric.itemwidth > width ? CGFloat(section.count) * Metric.itemwidth : (width + 1.0)
@@ -165,7 +165,7 @@ public class ShareSheetView: UIView {
         }) { _ in
             UIView.animate(withDuration: Metric.defaultDuration) {
                 self.backgroundColor = UIColor.black.withAlphaComponent(0.3)
-
+                self.shareSheetView.backgroundColor = UIColor(red: 0.937, green: 0.937, blue: 0.941, alpha: 1.0)
                 if #available(iOS 11, *) {
                     let margin = AppWindow.shared.window.safeAreaInsets.bottom
                     self.shareSheetView.y = Constants.Metric.screenHeight - self.shareSheetHeight - margin


### PR DESCRIPTION
回复输入框、搜索输入框 光标 显示根据主题色改变而改变（在黑色模式下光标很不明显，想移动光标很难定位）；
修复黑色模式下使用 Google 账号登录 左右 NavigationItem 颜色不明显；
详情右侧 更多，白色背景去除 透明度，黑色背景下由于背景透明度的设置看起来有点乱。